### PR TITLE
Update brew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you are on an Arch Linux based system, use
 
 If you are on Mac OSX, use
 
-    brew install badtouch
+    brew install authoscope
 
 To build from source, make sure you have [rust](https://rustup.rs/) and `libssl-dev` installed and run
 


### PR DESCRIPTION
Brew has renamed authoscope to use the new name, so this instruction should be updated as well.